### PR TITLE
Also ignore SIGTSTP to prevent someone from escaping with Control-Z

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -76,6 +76,7 @@ int main(int argc, char *argv[])
 	}
     }
     initscr();
+    signal(SIGQUIT, SIG_IGN);
     signal(SIGINT, SIG_IGN);
     signal(SIGTSTP, SIG_IGN);
     noecho();


### PR DESCRIPTION
Right now, a user can suspend an sl process running in their terminal, which can prevent them from actually learning from their mistakes. This patch fixes that issue.
