### PR TITLE
Also ignore SIGQUIT to prevent someone from escaping with Control-\

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -76,6 +76,7 @@ int main(int argc, char *argv[])
 	}
     }
     initscr();
+    signal(SIGQUIT, SIG_IGN);
     signal(SIGINT, SIG_IGN);
     noecho();
     leaveok(stdscr, TRUE);


### PR DESCRIPTION
Right now, a user can send SIGQUIT to `sl` process running in their terminal, which can prevent them from actually learning from their mistakes. This patch fixes that issue.
