### PR TITLE
Add -e option: Interrupt via Ctrl+C, Proper Makefile, and Cleanup sl.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 #==========================================
-#    Makefile: makefile for sl 5.1
+#    Makefile: makefile for sl 6.0
 #	Copyright 1993, 1998, 2014
 #                 Toyoda Masashi
 #		  (mtoyoda@acm.org)
-#	Last Modified: 2014/03/31
+#	Last Modified: 2014/06/16
 #==========================================
 
 CC=gcc
@@ -11,3 +11,15 @@ CFLAGS=-O
 
 sl: sl.c sl.h
 	$(CC) $(CFLAGS) -o sl sl.c -lncurses
+
+install:
+	gzip -9 -f sl.1
+	install -D -m 0775 sl /usr/bin/sl
+	install -Dm 644 sl.1.gz /usr/share/man/man1/sl.1.gz
+
+uninstall:
+	rm -rf /usr/bin/sl
+	rm -rf /usr/share/man/man1/sl.1.gz
+
+clean:
+	rm -rf sl

--- a/sl.1
+++ b/sl.1
@@ -3,13 +3,13 @@
 .\"
 .\"	@(#)sl.1
 .\"
-.TH SL 1 "March 31, 2014"
+.TH SL 1 "June 16, 2014"
 .SH NAME
 sl \- cure your bad habit of mistyping
 .SH SYNOPSIS
 .B sl
 [
-.B \-alFc
+.B \-alFce
 ]
 .SH DESCRIPTION
 .B sl
@@ -27,6 +27,9 @@ It flies like the galaxy express 999.
 .TP
 .B \-c
 C51 appears instead of D51.
+.TP
+.B \-e
+Allow interrupt by Ctrl+C.
 .PP
 .SH SEE ALSO
 .BR ls (1)

--- a/sl.1.ja
+++ b/sl.1.ja
@@ -3,7 +3,7 @@
 .\"		         (mtoyoda@acm.org)
 .\"	@(#)sl.1
 .\"
-.TH SL 1 "March 31, 2014"
+.TH SL 1 "June 16, 2014"
 .SH 名称
 sl \- キータイプを矯正します。
 .SH 形式

--- a/sl.c
+++ b/sl.c
@@ -1,11 +1,13 @@
 /*========================================
- *    sl.c: SL version 5.02
+ *    sl.c: SL version 6.00
  *        Copyright 1993,1998,2014
  *                  Toyoda Masashi
  *                  (mtoyoda@acm.org)
- *        Last Modified: 2014/06/03
+ *        Last Modified: 2014/06/16
  *========================================
  */
+/* sl version 6.00 : add -e option                                           */
+/*                                           by Hiroyuki Yamamoto 2014/06/16 */
 /* sl version 5.02 : Fix compiler warnings.                                  */
 /*                                              by Jeff Schwab    2014/06/03 */
 /* sl version 5.01 : removed cursor and handling of IO                       */
@@ -41,18 +43,11 @@
 #include <unistd.h>
 #include "sl.h"
 
-void add_smoke(int y, int x);
-void add_man(int y, int x);
-int add_C51(int x);
-int add_D51(int x);
-int add_sl(int x);
-void option(char *str);
-int my_mvaddstr(int y, int x, char *str);
-
 int ACCIDENT  = 0;
 int LOGO      = 0;
 int FLY       = 0;
 int C51       = 0;
+int INTR      = 0;
 
 int my_mvaddstr(int y, int x, char *str)
 {
@@ -73,6 +68,7 @@ void option(char *str)
             case 'F': FLY      = 1; break;
             case 'l': LOGO     = 1; break;
             case 'c': C51      = 1; break;
+            case 'e': INTR     = 1; break;
             default:                break;
         }
     }
@@ -88,7 +84,10 @@ int main(int argc, char *argv[])
         }
     }
     initscr();
-    signal(SIGINT, SIG_IGN);
+    if (INTR == 0) {
+        signal(SIGINT, SIG_IGN);
+    }
+    signal(SIGTSTP, SIG_IGN);
     noecho();
     curs_set(0);
     nodelay(stdscr, TRUE);
@@ -112,7 +111,6 @@ int main(int argc, char *argv[])
     mvcur(0, COLS - 1, LINES - 1, 0);
     endwin();
 }
-
 
 int add_sl(int x)
 {

--- a/sl.h
+++ b/sl.h
@@ -1,17 +1,28 @@
 /*========================================
- *    sl.h: SL version 5.02
+ *    sl.h: SL version 6.00
  *	Copyright 1993,2002,2014
  *                Toyoda Masashi
  *		  (mtoyoda@acm.org)
- *	Last Modified: 2014/06/03
+ *	Last Modified: 2014/06/16
  *========================================
  */
+
+#ifndef SL_H
+#define SL_H
+
+/* Function Prototypes */
+void add_smoke(int y, int x);
+void add_man(int y, int x);
+int add_C51(int x);
+int add_D51(int x);
+int add_sl(int x);
+void option(char *str);
+int my_mvaddstr(int y, int x, char *str);
 
 #define D51HIGHT	10
 #define D51FUNNEL	 7
 #define D51LENGTH	83
 #define D51PATTERNS	 6
-
 
 #define D51STR1  "      ====        ________                ___________ "
 #define D51STR2  "  _D _|  |_______/        \\__I_I_____===__|_________| "
@@ -148,3 +159,5 @@
 #define C51WH12 "------'|oOo|=[]=-      ||      ||      |  ||=======_|__"
 #define C51WH13 "/~\\____|___|/~\\_|  O=======O=======O   |__|+-/~\\_|     "
 #define C51WH14 "\\_/         \\_/  \\____/  \\____/  \\____/      \\_/       "
+
+#endif /* SL_H */


### PR DESCRIPTION
Add -e option to allow interrupt via Ctrl+C. So users can, `alias sl='sl -e'` if they don't want to wait each time for sl to finish running.
- Makefile now includes: install, uninstall, and clean. Therefore, users can install sl by running:

```
make
make install
```
- Add header guards to `sl.h`, and move function prototypes to `sl.h`.
- `README.ja.md` and `sl.1.ja` still need to be updated (I don't know Japanese).
