### PR TITLE
Period at the end of the -l option

### DIFF
--- a/sl.1
+++ b/sl.1
@@ -20,7 +20,7 @@ is a highly advanced animation program for curing your bad habit of mistyping.
 An accident is occurring. People cry for help.
 .TP
 .B \-l
-Little version
+Little version.
 .TP
 .B \-F
 It flies like the galaxy express 999.


### PR DESCRIPTION
Added a period (.) at the end of the description of the -l option in the
manpage ("little version"), to align it with the other options displayed
there.

Signed-off-by: Allon Mureinik mureinik@gmail.com
