### PR TITLE
Because when you type `sl` you technically failed

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -38,6 +38,7 @@
 
 #include <curses.h>
 #include <signal.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include "sl.h"
 
@@ -111,6 +112,7 @@ int main(int argc, char *argv[])
     }
     mvcur(0, COLS - 1, LINES - 1, 0);
     endwin();
+    return(EXIT_FAILURE);
 }
 
 


### PR DESCRIPTION
- Configures the exit code to reflect your failure
- brings in the use of EXIT_FAILURE for portability
