### PR TITLE
Allow longer locomotive

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -151,7 +151,7 @@ int add_sl(int x)
         add_man(y + 1, x + 14);
         yoffset = 0;
         for (int j = 0; j <= LOGO; j++) {
-            yoffset = 2 * FLY + 2 * j * FLY;
+            yoffset = FLY * (2 + 2 * j);
             add_man(y + 1 + py2 + yoffset, x + 45 + offset * j);
             add_man(y + 1 + py2 + yoffset, x + 53 + offset * j);
         }

--- a/sl.c
+++ b/sl.c
@@ -69,11 +69,11 @@ void option(char *str)
 
     while (*str != '\0') {
         switch (*str++) {
-            case 'a': ACCIDENT = 1; break;
-            case 'F': FLY      = 1; break;
-            case 'l': LOGO     = 1; break;
-            case 'c': C51      = 1; break;
-            default:                break;
+            case 'l': LOGO     += 1; break;
+            case 'a': ACCIDENT  = 1; break;
+            case 'F': FLY       = 1; break;
+            case 'c': C51       = 1; break;
+            default:                 break;
         }
     }
 }
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
     scrollok(stdscr, FALSE);
 
     for (x = COLS - 1; ; --x) {
-        if (LOGO == 1) {
+        if (LOGO >= 1) {
             if (add_sl(x) == ERR) break;
         }
         else if (C51 == 1) {

--- a/sl.c
+++ b/sl.c
@@ -130,7 +130,7 @@ int add_sl(int x)
     static char *car[LOGOHIGHT + 1]
         = {LCAR1, LCAR2, LCAR3, LCAR4, LCAR5, LCAR6, DELLN};
 
-    int i, y, py1 = 0, py2 = 0, py3 = 0;
+    int i, y, py1 = 0, py2 = 0, py3 = 0, offset = 21, yoffset = 0;
 
     if (x < - LOGOLENGTH)  return ERR;
     y = LINES / 2 - 3;
@@ -142,13 +142,19 @@ int add_sl(int x)
     for (i = 0; i <= LOGOHIGHT; ++i) {
         my_mvaddstr(y + i, x, sl[(LOGOLENGTH + x) / 3 % LOGOPATTERNS][i]);
         my_mvaddstr(y + i + py1, x + 21, coal[i]);
-        my_mvaddstr(y + i + py2, x + 42, car[i]);
-        my_mvaddstr(y + i + py3, x + 63, car[i]);
+        for (int j = 0; j <= LOGO; j++) {
+            yoffset = 2 * j * FLY;
+            my_mvaddstr(y + i + py3 +  yoffset, x + 42 + offset * j, car[i]);
+        }
     }
     if (ACCIDENT == 1) {
         add_man(y + 1, x + 14);
-        add_man(y + 1 + py2, x + 45);  add_man(y + 1 + py2, x + 53);
-        add_man(y + 1 + py3, x + 66);  add_man(y + 1 + py3, x + 74);
+        yoffset = 0;
+        for (int j = 0; j <= LOGO; j++) {
+            yoffset = 2 * FLY + 2 * j * FLY;
+            add_man(y + 1 + py2 + yoffset, x + 45 + offset * j);
+            add_man(y + 1 + py2 + yoffset, x + 53 + offset * j);
+        }
     }
     add_smoke(y - 1, x + LOGOFUNNEL);
     return OK;


### PR DESCRIPTION
This pull request adds the functionality of drawing longer locomotives according to the number o `-l` options passed.
If the user types `sl -l`, the locomotive has two more cars as before. With this patch, when the user types "sl -ll", the locomotive will have 2 cars from the first `l` and one more car from the second, 3 more cars in total.
This functionality works for an infinite number of `l`s passed. Meaning that the number of cars will be the number of `l`s in thecommand line and + 1.

It still works with `-F` and `-a`.

Thanks for the help from @flavioamieiro.
