### PR TITLE
Add SIGINT configuration and disco mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #==========================================
 
 CC=gcc
-CFLAGS=-O -Wall
+CFLAGS=-O3 -Wall
 
 all: sl
 

--- a/sl.1
+++ b/sl.1
@@ -5,28 +5,37 @@
 .\"
 .TH SL 1 "March 31, 2014"
 .SH NAME
-sl \- cure your bad habit of mistyping
+sl \- display animations aimed to correct users who accidentally enter sl instead of ls.
 .SH SYNOPSIS
 .B sl
 [
-.B \-alFc
+.B \-acdeFlw
 ]
 .SH DESCRIPTION
 .B sl
-is a highly advanced animation program for curing your bad habit of mistyping.
+Displays animations aimed to correct users who accidentally enter sl instead of ls.  SL stands for Steam Locomotive.
 .PP
 .TP
 .B \-a
 An accident is occurring. People cry for help.
 .TP
-.B \-l
-Little version.
+.B \-c
+C51 appears instead of D51.
+.TP
+.B \-d
+Disco mode. Alternate colors during animation.
+.TP
+.B \-e
+Escape. Allow interrupt by Ctrl+C.
 .TP
 .B \-F
 It flies like the galaxy express 999.
 .TP
-.B \-c
-C51 appears instead of D51.
+.B \-l
+Little version.
+.TP
+.B \-w
+Windy day. Locomotive moves faster.
 .PP
 .SH SEE ALSO
 .BR ls (1)

--- a/sl.c
+++ b/sl.c
@@ -53,11 +53,12 @@ void option(char *str);
 int my_mvaddstr(int y, int x, char *str);
 
 int ACCIDENT  = 0;
-int LOGO      = 0;
-int FLY       = 0;
 int C51       = 0;
 int DISCO     = 0;
 int SIGNAL    = 1;
+int FLY       = 0;
+int LOGO      = 0;
+int WIND      = 0;
 
 int my_mvaddstr(int y, int x, char *str)
 {
@@ -70,16 +71,17 @@ int my_mvaddstr(int y, int x, char *str)
 
 void option(char *str)
 {
-    extern int ACCIDENT, LOGO, FLY, C51, DISCO, SIGNAL;
+    extern int ACCIDENT, C51, DISCO, SIGNAL, FLY, LOGO, WIND;
 
     while (*str != '\0') {
         switch (*str++) {
             case 'a': ACCIDENT = 1; break;
-            case 'F': FLY      = 1; break;
-            case 'l': LOGO     = 1; break;
             case 'c': C51      = 1; break;
             case 'd': DISCO    = 1; break;
             case 'e': SIGNAL   = 0; break;
+            case 'F': FLY      = 1; break;
+            case 'l': LOGO     = 1; break;
+            case 'w': WIND     = 200; break;
             default:                break;
         }
     }
@@ -121,7 +123,7 @@ int main(int argc, char *argv[])
         }
         getch();
         refresh();
-        usleep(40000);
+        usleep(40000 - (WIND * 100));
     }
     mvcur(0, COLS - 1, LINES - 1, 0);
     endwin();

--- a/sl.c
+++ b/sl.c
@@ -39,6 +39,7 @@
 /*                                              by Toyoda Masashi 1992/12/11 */
 
 #include <curses.h>
+#include <limits.h>
 #include <signal.h>
 #include <unistd.h>
 #include "sl.h"
@@ -55,6 +56,8 @@ int ACCIDENT  = 0;
 int LOGO      = 0;
 int FLY       = 0;
 int C51       = 0;
+int DISCO     = 0;
+int SIGNAL    = 1;
 
 int my_mvaddstr(int y, int x, char *str)
 {
@@ -67,7 +70,7 @@ int my_mvaddstr(int y, int x, char *str)
 
 void option(char *str)
 {
-    extern int ACCIDENT, LOGO, FLY, C51;
+    extern int ACCIDENT, LOGO, FLY, C51, DISCO, SIGNAL;
 
     while (*str != '\0') {
         switch (*str++) {
@@ -75,6 +78,8 @@ void option(char *str)
             case 'F': FLY      = 1; break;
             case 'l': LOGO     = 1; break;
             case 'c': C51      = 1; break;
+            case 'd': DISCO    = 1; break;
+            case 'e': SIGNAL   = 0; break;
             default:                break;
         }
     }
@@ -90,7 +95,14 @@ int main(int argc, char *argv[])
         }
     }
     initscr();
-    signal(SIGINT, SIG_IGN);
+    if (DISCO == 1) {
+        start_color();
+        init_pair(4, COLOR_RED, COLOR_BLACK);
+        init_pair(3, COLOR_YELLOW, COLOR_BLACK);
+        init_pair(2, COLOR_GREEN, COLOR_BLACK);
+        init_pair(1, COLOR_CYAN, COLOR_BLACK);
+    }
+    if (SIGNAL) signal(SIGINT, SIG_IGN);
     noecho();
     curs_set(0);
     nodelay(stdscr, TRUE);
@@ -279,6 +291,8 @@ void add_smoke(int y, int x)
                                  2,  2, 2, 3, 3, 3             };
     int i;
 
+    if (DISCO && (x + INT_MAX/2) % 4 == 2)
+        attron(COLOR_PAIR((x + INT_MAX/2) / 16 % 4 + 1));
     if (x % 4 == 0) {
         for (i = 0; i < sum; ++i) {
             my_mvaddstr(S[i].y, S[i].x, Eraser[S[i].ptrn]);


### PR DESCRIPTION
If `-e` is provided, allows interrupt by Ctrl+C.
If `-d` is provided, disco mode activates: train changes color during travel.

I'd bother to separate these into two PRs but I see there are already 6 other open PRs.