### PR TITLE
Set cbreak when starting

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -91,6 +91,7 @@ int main(int argc, char *argv[])
     }
     initscr();
     signal(SIGINT, SIG_IGN);
+    cbreak();
     noecho();
     curs_set(0);
     nodelay(stdscr, TRUE);


### PR DESCRIPTION
From nodelay(3)

Initially the terminal may or may not be in cbreak mode, as the mode is
inherited; therefore, a program should call cbreak or nocbreak
explicitly. Most interactive programs using curses set the cbreak mode.
Note that cbreak overrides raw. [See curs_getch(3X) for a discussion of
how these routines interact with echo and noecho.]

This allows sl to function perfectly on NetBSD Curses.