### PR TITLE
Link to curses rather than ncurses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CFLAGS=-O -Wall
 all: sl
 
 sl: sl.c sl.h
-	$(CC) $(CFLAGS) -o sl sl.c -lncurses
+	$(CC) $(CFLAGS) -o sl sl.c -lcurses
 
 clean:
 	rm -f sl


### PR DESCRIPTION
NetBSD doesn't have ncurses and sl works fine after PR#63
is merged.
ncurses default install allows linking via -lcurses as well.
Let's work with both.