### PR TITLE
ignore sigquit as well as sigint

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -91,6 +91,7 @@ int main(int argc, char *argv[])
     }
     initscr();
     signal(SIGINT, SIG_IGN);
+    signal(SIGQUIT, SIG_IGN);
     noecho();
     curs_set(0);
     nodelay(stdscr, TRUE);


### PR DESCRIPTION
ignore sigquit as well, otherwise you can just send ^\ instead of ^C. sneaky.