### PR TITLE
Add -C and -t options to for colours and a track under the train.

### DIFF
--- a/sl.1
+++ b/sl.1
@@ -3,7 +3,7 @@
 .\"
 .\"	@(#)sl.1
 .\"
-.TH SL 1 "March 31, 2014"
+.TH SL 1 "April 18, 2020"
 .SH NAME
 sl \- cure your bad habit of mistyping
 .SH SYNOPSIS

--- a/sl.1
+++ b/sl.1
@@ -23,10 +23,16 @@ An accident is occurring. People cry for help.
 Little version.
 .TP
 .B \-F
-It flies like the galaxy express 999.
+It flies like the galaxy express 999. Overrides previous -t.
 .TP
 .B \-c
 C51 appears instead of D51.
+.TP
+.B \-t
+It has tracks. Much realism. Overrides previous -F.
+.TP
+.B \-C
+Colors! The locomotive exists outside of the bounds of monochrome.
 .PP
 .SH SEE ALSO
 .BR ls (1)

--- a/sl.c
+++ b/sl.c
@@ -106,6 +106,7 @@ int main(int argc, char *argv[])
         use_default_colors();
     }
     signal(SIGINT, SIG_IGN);
+    signal(SIGQUIT, SIG_IGN);
     noecho();
     curs_set(0);
     nodelay(stdscr, TRUE);

--- a/sl.c
+++ b/sl.c
@@ -3,7 +3,7 @@
  *        Copyright 1993,1998,2014-2015
  *                  Toyoda Masashi
  *                  (mtoyoda@acm.org)
- *        Last Modified: 2014/06/03
+ *        Last Modified: 2020/04/18
  *========================================
  */
 /* sl verdion 6.00 : Added -t(rack) and -C(olors) options.                   */


### PR DESCRIPTION

![screenshot](https://user-images.githubusercontent.com/49550853/79632288-51564400-8156-11ea-990d-11dc32ea1292.png)
[note that the colours are wrong in the screenshot because of my bash config]

The -C option adds colours. The locomotive is drawn in red and the coal cart in yellow. When using with -l, the carriages are drawn in green.

The -t option draws a track under the train. When used with -F, the second flag to be supplied will be used. EG -tF flies and -Ft draws the track.