### PR TITLE
SIGTSTP signal added with sighandler disposition

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -56,6 +56,17 @@ int LOGO      = 0;
 int FLY       = 0;
 int C51       = 0;
 
+void sighandler(int signo)
+{
+    switch(signo) {
+        case SIGTSTP:
+            break;
+        case SIGINT:
+            break;
+    }
+}
+
+
 int my_mvaddstr(int y, int x, char *str)
 {
     for ( ; x < 0; ++x, ++str)
@@ -90,7 +101,8 @@ int main(int argc, char *argv[])
         }
     }
     initscr();
-    signal(SIGINT, SIG_IGN);
+    signal(SIGINT, sighandler);
+    signal(SIGTSTP, sighandler);
     noecho();
     curs_set(0);
     nodelay(stdscr, TRUE);


### PR DESCRIPTION
Use the SIGTSTP signal to ignore the ctrl-z while sl running. 

SIGTSTP signal can be used instead of SIGSTOP which allows us to ignore the signal while sl is 
running in the background. Since SIGSTOP cannot be caught  and ignored, this would be nice feature to have. Also I have added a sighandler just to pass signal disposition to the syscall itself. 

Signed-off-by: Yadav Lamichhane <omegazyadav1@gmail.com>