### PR TITLE
Add Continuous Mode (-r) to Run Train Continuously

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -55,6 +55,7 @@ int ACCIDENT  = 0;
 int LOGO      = 0;
 int FLY       = 0;
 int C51       = 0;
+int CONTINUOUS = 0;  // New variable to indicate continuous mode
 
 int my_mvaddstr(int y, int x, char *str)
 {
@@ -75,6 +76,7 @@ void option(char *str)
             case 'F': FLY      = 1; break;
             case 'l': LOGO     = 1; break;
             case 'c': C51      = 1; break;
+             case 'r': CONTINUOUS = 1; break;  // Handle -r option
             default:                break;
         }
     }
@@ -83,6 +85,7 @@ void option(char *str)
 int main(int argc, char *argv[])
 {
     int x, i;
+    int ch = 0;  // Variable to store user input, initialized to 0
 
     for (i = 1; i < argc; ++i) {
         if (*argv[i] == '-') {
@@ -97,26 +100,32 @@ int main(int argc, char *argv[])
     leaveok(stdscr, TRUE);
     scrollok(stdscr, FALSE);
 
-    for (x = COLS - 1; ; --x) {
-        if (LOGO == 1) {
-            if (add_sl(x) == ERR) break;
+    do {
+        for (x = COLS - 1; x >= -80; --x) {  // Loop the train from right to left
+            if (LOGO == 1) {
+                if (add_sl(x) == ERR) break;
+            }
+            else if (C51 == 1) {
+                if (add_C51(x) == ERR) break;
+            }
+            else {
+                if (add_D51(x) == ERR) break;
+            }
+            ch = getch();  // Get user input
+            if (ch == 'q') {  // Check if 'q' is pressed
+                CONTINUOUS = 0;  // Set CONTINUOUS to 0 to stop the loop
+                break;
+            }
+            refresh();
+            usleep(40000);
         }
-        else if (C51 == 1) {
-            if (add_C51(x) == ERR) break;
-        }
-        else {
-            if (add_D51(x) == ERR) break;
-        }
-        getch();
-        refresh();
-        usleep(40000);
-    }
+    } while (CONTINUOUS);  // Repeat the loop if in continuous mode
+
     mvcur(0, COLS - 1, LINES - 1, 0);
     endwin();
 
     return 0;
 }
-
 
 int add_sl(int x)
 {


### PR DESCRIPTION
This pull request adds a new feature to the `sl` command, allowing the train animation to run continuously when the `-c` option is used. 

## Changes
- Added a new command-line option `-r`.
- Modified the main animation loop to run continuously if `-r` is specified.

## Usage
To run the train continuously, use:
`sl -r`
To quit running the train, press:
`q`

## Reason
This feature provides a fun way to keep the `sl` animation running without manual intervention.

Please review the changes and let me know if any adjustments are needed. Thank you!